### PR TITLE
Feat/vote failed notification

### DIFF
--- a/infection/backend/sockets.js
+++ b/infection/backend/sockets.js
@@ -258,11 +258,11 @@ module.exports = server => {
         gameRooms[socket.game].playerCount
       ) {
         // More accepts than rejects for team proposal
-        const voteSucceeds =
+        const missionRosterApproved =
           store.getState().proposalVotes[socket.game].voteSuccess >
           store.getState().proposalVotes[socket.game].voteFail;
         let results;
-        voteSucceeds === false ? (results = 1) : (results = 0);
+        missionRosterApproved === false ? (results = 1) : (results = 0);
         const round = store.getState().game[socket.game].round;
         const rosterLength = grid[gameRooms[socket.game].playerCount][round - 1];
         const roundLeader =
@@ -271,7 +271,7 @@ module.exports = server => {
           ];
         // Send roster vote results back to client
         io.in(socket.game).emit('roster vote result', {
-          voteSucceeds,
+          missionRosterApproved,
           vote: gameRooms[socket.game].proposalResults,
         });
         // reset PAL3000's voted status
@@ -282,7 +282,7 @@ module.exports = server => {
         setTimeout(() => {
           // If vote succeeds, reset fail count, mission votes,
           // move to cure or sabotage vote via on mission event
-          if (voteSucceeds) {
+          if (missionRosterApproved) {
             store.dispatch(resetMissionVotes(socket.game));
             console.log(
               chalk.bgWhite.blue(
@@ -293,7 +293,7 @@ module.exports = server => {
             store.dispatch(resetFail(socket.game));
             gameRooms[socket.game].proposalResults = [];
             io.in(socket.game).emit('on mission');
-          } else if (!voteSucceeds) {
+          } else if (!missionRosterApproved) {
             // If vote fails, check if this is third fail on current
             if (store.getState().game[socket.game].failCount === 2) {
               // If this is the third failed vote on current round,

--- a/infection/src/components/game.js
+++ b/infection/src/components/game.js
@@ -37,12 +37,13 @@ class Game extends Component {
       missionRoster: [],
       rosterLength: 0,
       round: 0,
-      rosterUnapproved: 0,
+      missionRosterUnapprovedCount: 0,
       team: [],
       teamAssembled: false,
       username: undefined,
       usersVoteRecord: [],
       votedOnRoster: false,
+      missionRosterApproved: false,
     };
   }
 
@@ -67,7 +68,7 @@ class Game extends Component {
       const { round } = this.state;
       if (data.round > round) {
         this.setState({
-          rosterUnapproved: 0,
+          missionRosterUnapprovedCount: 0,
         });
       }
       this.setState({
@@ -90,16 +91,20 @@ class Game extends Component {
         leaderSubmitRoster: true,
       });
     });
-    socket.on('roster vote result', ({ voteSucceeds, vote }) => {
+    socket.on('roster vote result', ({ missionRosterApproved, vote }) => {
       this.setState(
-        { allUsersVotedOnRoster: true, usersVoteRecord: vote },
+        {
+          allUsersVotedOnRoster: true,
+          usersVoteRecord: vote,
+          missionRosterApproved,
+        },
         () => {
-          // set state of rosterUnapproved based on result
+          // set state of missionRosterUnapprovedCount based on result
           // for every failed vote increment by one
-          if (!voteSucceeds) {
-            const { rosterUnapproved } = this.state;
+          if (!missionRosterApproved) {
+            const { missionRosterUnapprovedCount } = this.state;
             this.setState({
-              rosterUnapproved: rosterUnapproved + 1,
+              missionRosterUnapprovedCount: missionRosterUnapprovedCount + 1,
             });
           }
         }
@@ -176,7 +181,7 @@ class Game extends Component {
             missionRoster: [],
             rosterLength: 0,
             round: 0,
-            rosterUnapproved: 0,
+            missionRosterUnapprovedCount: 0,
             team: [],
             teamAssembled: false,
             username: undefined,

--- a/infection/src/views/game/gameView.js
+++ b/infection/src/views/game/gameView.js
@@ -26,7 +26,7 @@ const GameView = ({
       <Col md={5} />
       <Col md={2}>
         <Header
-          rosterUnapproved={game.rosterUnapproved}
+          missionRosterUnapprovedCount={game.missionRosterUnapprovedCount}
           leaderSubmitRoster={game.leaderSubmitRoster}
         />
       </Col>

--- a/infection/src/views/game/round/rosterVote/roster/hasLeaderSubmittedRoster.js
+++ b/infection/src/views/game/round/rosterVote/roster/hasLeaderSubmittedRoster.js
@@ -11,6 +11,8 @@ const HasLeaderSubmittedRoster = ({
 }) =>
   game.leaderSubmitRoster ? (
     <RosterVote
+      missionRosterApproved={game.missionRosterApproved}
+      missionRosterUnapprovedCount={game.missionRosterUnapprovedCount}
       rosterApproved={game.rosterApproved}
       missionRoster={game.missionRoster}
       leader={game.leader}

--- a/infection/src/views/game/round/rosterVote/rosterVote.js
+++ b/infection/src/views/game/round/rosterVote/rosterVote.js
@@ -5,6 +5,8 @@ import WaitingForRosterVote from '../../waiting/waitingForRosterVote';
 import Vote from './vote';
 
 const RosterVote = ({
+  missionRosterApproved,
+  missionRosterUnapprovedCount,
   allUsersVotedOnRoster,
   handleRosterVote,
   leader,
@@ -14,7 +16,11 @@ const RosterVote = ({
 }) =>
   votedOnRoster ? (
     allUsersVotedOnRoster ? (
-      <UsersVoteOnRosterList usersVoteRecord={usersVoteRecord} />
+      <UsersVoteOnRosterList
+        usersVoteRecord={usersVoteRecord}
+        missionRosterUnapprovedCount={missionRosterUnapprovedCount}
+        missionRosterApproved={missionRosterApproved}
+      />
     ) : (
       <WaitingForRosterVote />
     )

--- a/infection/src/views/game/round/rosterVote/usersVoteOnRosterList.js
+++ b/infection/src/views/game/round/rosterVote/usersVoteOnRosterList.js
@@ -1,9 +1,24 @@
 import React from 'react';
 import { Col, Row, ListGroup, ListGroupItem } from 'react-bootstrap';
 
-const UsersVoteOnRosterList = ({ usersVoteRecord }) => (
+const UsersVoteOnRosterList = ({
+  usersVoteRecord,
+  missionRosterUnapprovedCount,
+  missionRosterApproved,
+}) => (
   <Row>
-    <h4>How the Team Voted</h4>
+    {missionRosterApproved ? (
+      <h2>Mission Roster Approved!</h2>
+    ) : (
+      <div>
+        <h2>Mission Roster Not Approved!</h2>
+        <h3>
+          Vote {missionRosterUnapprovedCount}
+          /3 Failed
+        </h3>
+      </div>
+    )}
+    <h4>How the Team Voted:</h4>
     <Col md={4} xs={3} />
     <Col md={4} xs={6}>
       <ListGroup>

--- a/infection/src/views/game/round/round.js
+++ b/infection/src/views/game/round/round.js
@@ -11,7 +11,7 @@ const Round = ({
 }) =>
   // TODO?: change line 13, server will update game state on client instead
   game.missionFailed ? (
-    // game.rosterUnapproved === 3 ? (
+    // game.missionRosterUnapprovedCount === 3 ? (
 
     <Fail />
   ) : (

--- a/infection/src/views/game/shared/header.js
+++ b/infection/src/views/game/shared/header.js
@@ -6,14 +6,14 @@ import logo1 from '../../../images/logo-yellow.png';
 import logo2 from '../../../images/logo-orange.png';
 import logo3 from '../../../images/Logo-vector.png';
 
-const Header = ({ rosterUnapproved, leaderSubmitRoster }, logo) => {
+const Header = ({ missionRosterUnapprovedCount, leaderSubmitRoster }, logo) => {
   !leaderSubmitRoster
     ? (logo = logo3)
-    : rosterUnapproved === 3
+    : missionRosterUnapprovedCount === 3
       ? (logo = logo3)
-      : rosterUnapproved === 2
+      : missionRosterUnapprovedCount === 2
         ? (logo = logo2)
-        : rosterUnapproved === 1
+        : missionRosterUnapprovedCount === 1
           ? (logo = logo1)
           : (logo = logo0);
 


### PR DESCRIPTION
Informs players explicitly (e.g. 'Mission Roster Approved!') as to whether the current leader's proposed mission roster has been approved and not, and displays the number of failed votes (e.g. 1/3) to show how many failed votes are possible before a failed mission result. 